### PR TITLE
fix: reset copy button text when new text was encrypted

### DIFF
--- a/site/_i18n/de.yml
+++ b/site/_i18n/de.yml
@@ -34,5 +34,6 @@ imprint:
 result:
   description: Verschicken Sie diesen Link
   copy: Kopieren
+  copied: Kopiert
   returnToCopy: EINGABE drücken, um den Link in die Zwischenablage zu kopieren
   present: Bitte sehr

--- a/site/_i18n/en.yml
+++ b/site/_i18n/en.yml
@@ -34,5 +34,6 @@ imprint:
 result:
   description: Send this link to the recipient
   copy: Copy
+  copied: Copied!
   returnToCopy: Press RETURN to copy the link to clipboard
   present: Here you are

--- a/site/assets/keedrop.js
+++ b/site/assets/keedrop.js
@@ -59,6 +59,7 @@
         source.setSelectionRange(0, 9999);
         callback(document.execCommand("copy"));
       } catch (e) {
+        console.error("Could not copy to clipboard", e)
         callback(false);
       }
     }
@@ -74,7 +75,9 @@
     event.preventDefault && event.preventDefault();
     copyToClipboard(document.getElementById("resultBox"), function(success) {
       if (success) {
-        event.srcElement.innerText = "Copied";
+        var button = event.srcElement;
+        button.setAttribute("data-text", button.innerText);
+        button.innerText = button.getAttribute("data-copied");
       }
     });
     return false;
@@ -96,6 +99,8 @@
   }
 
   function showResult(result) {
+    var copyButton = document.getElementById("copy")
+    copyButton.innerText = copyButton.getAttribute("data-text") || copyButton.innerText
     var resultBox = document.getElementById("resultBox");
     resultBox.value = result;
     resultBox.parentNode.parentNode.parentNode.classList.add("reveal");

--- a/site/index.html
+++ b/site/index.html
@@ -23,7 +23,7 @@ title: titles.home
   <div class="column">
     <form>
       <label for="resultBox">{% t result.description %}:</label>
-      <input id="resultBox" type="text" readonly/><button id="copy">{% t result.copy %}</button>
+      <input id="resultBox" type="text" readonly/><button id="copy" data-copied="{% t result.copied %}">{% t result.copy %}</button>
       <div class="returnToCopy">({% t result.returnToCopy %})</div>
     </form>
   </div>


### PR DESCRIPTION
Maybe we should change the whole flow of this. The result box could be hidden when a new text to encrypt is entered.
Or the result form replaces the input form and add a new button to the result form "Create another secret link".

Closes #56