### PR TITLE
fix: status page badge

### DIFF
--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -47,7 +47,7 @@
             <img src="https://img.shields.io/badge/source%20code-gray?logo=github&style=flat-square" height="20" width="95" alt="{% t titles.source.badge %}">
           </a>
           <a href="https://status.keedrop.com" title="{% t titles.status.title %}">
-            <img src="https://img.shields.io/uptimerobot/ratio/m785003856-8aa9823b6992a1796824c5a6?style=flat-square" height="20" width="110" alt="{% t titles.status.badge %}">
+            <img src="https://img.shields.io/uptimerobot/ratio/m788230486-3c11972c41ef027e06ea4267?style=flat-square" height="20" width="110" alt="{% t titles.status.badge %}">
           </a>
         </nav>
       </footer>


### PR DESCRIPTION
somehow update robot has changed the API keys for the monitor.

|old|new|
|-|-|
|![](https://img.shields.io/uptimerobot/ratio/m785003856-8aa9823b6992a1796824c5a6?style=flat-square)|![](https://img.shields.io/uptimerobot/ratio/m788230486-3c11972c41ef027e06ea4267?style=flat-square)|